### PR TITLE
chore(skills): reorganize skill metadata

### DIFF
--- a/.ai/skills/commit-or-pr-message/SKILL.md
+++ b/.ai/skills/commit-or-pr-message/SKILL.md
@@ -1,4 +1,8 @@
 ---
+# SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
+#
+# SPDX-License-Identifier: CC-BY-NC-4.0
+
 name: commit-or-pr-message
 description: Generates a concise and descriptive commit or PR message based on the code changes.
 license: CC0-1.0

--- a/.ai/skills/shell-script/SKILL.md
+++ b/.ai/skills/shell-script/SKILL.md
@@ -1,4 +1,8 @@
 ---
+# SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
+#
+# SPDX-License-Identifier: CC-BY-NC-4.0
+
 name: shell-script
 description: Write a shell script
 license: CC0-1.0

--- a/.ai/skills/skill-creator/SKILL.md
+++ b/.ai/skills/skill-creator/SKILL.md
@@ -1,0 +1,102 @@
+<!--
+SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
+
+SPDX-License-Identifier: CC-BY-NC-4.0
+-->
+
+# Skill Creator
+
+Guide for creating effective skills that extend Claude's capabilities.
+
+## About Skills
+
+Skills are modular, self-contained packages that extend Claude's capabilities by providing specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific domains.
+
+### What Skills Provide
+
+1. **Specialized workflows** - Multi-step procedures for specific domains
+2. **Tool integrations** - Instructions for working with specific file formats or APIs
+3. **Domain expertise** - Company-specific knowledge, schemas, business logic
+4. **Bundled resources** - Scripts, references, and assets for complex tasks
+
+## Core Principles
+
+### Concise is Key
+
+The context window is a public good. Only add context Claude doesn't already have.
+
+**Default assumption: Claude is already very smart.** Challenge each piece of information: "Does Claude really need this explanation?"
+
+Prefer concise examples over verbose explanations.
+
+### Anatomy of a Skill
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description)
+│   └── Markdown instructions
+└── Bundled Resources (optional)
+    ├── scripts/      - Executable code
+    ├── references/   - Documentation
+    └── assets/       - Templates, images
+```
+
+## SKILL.md Components
+
+### Frontmatter (YAML)
+
+```yaml
+---
+name: skill-name
+description: What the skill does. Use when [activation trigger].
+---
+```
+
+The description is the primary triggering mechanism. Include both what the skill does AND when to use it.
+
+### Body (Markdown)
+
+Instructions and guidance. Only loaded AFTER the skill triggers.
+
+## Bundled Resources
+
+### Scripts (`scripts/`)
+
+Executable code for tasks requiring deterministic reliability.
+
+### References (`references/`)
+
+Documentation loaded as needed into context.
+
+### Assets (`assets/`)
+
+Files used in output (templates, images, fonts).
+
+## Progressive Disclosure
+
+Skills use three-level loading:
+
+1. **Metadata** - Always in context (~100 words)
+2. **SKILL.md body** - When skill triggers (<5k words)
+3. **Bundled resources** - As needed
+
+Keep SKILL.md under 500 lines. Split content when approaching this limit.
+
+## Skill Creation Process
+
+1. **Understand** - Gather concrete usage examples
+2. **Plan** - Identify reusable scripts, references, assets
+3. **Initialize** - Create skill directory structure
+4. **Edit** - Implement resources and write SKILL.md
+5. **Package** - Bundle for distribution
+6. **Iterate** - Improve based on real usage
+
+## What NOT to Include
+
+- README.md
+- INSTALLATION_GUIDE.md
+- CHANGELOG.md
+- User-facing documentation
+
+Skills are for AI agents, not humans. Only include what Claude needs to do the job.

--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,1 +1,0 @@
-skills/commit-or-pr-message/SKILL.md

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build:
 	./gradlew build --console=plain
 
 .PHONY: merge
-merge: merge-head push create-pr build watch-full merge-squash
+merge: merge-head push create-pr watch-full merge-squash
 
 .PHONY: clean
 clean:
@@ -64,11 +64,10 @@ up-wrapper:
 up-all-deps:
 	./gradlew build --write-locks --scan --console=plain | grep -e FAILED -e https
 
-create-pr:
+create-pr: build
 	@tmp_dir=$$(mktemp -d); \
 	head_before=$$(git rev-parse HEAD); \
 	if gh pr view --json number > /dev/null 2>&1; then \
-		./gradlew check; \
 		printf '%s\n' "Updating PR message..."; \
 		./scripts/pr-message.sh --title-file "$$tmp_dir/title.txt" --body-file "$$tmp_dir/body.txt" \
 		  --skill-file "$(SKILL_FILE)" || exit 0; \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,13 @@ build:
 	./gradlew build --console=plain
 
 .PHONY: merge
-merge: merge-head push create-pr watch-full merge-squash
+merge: merge-head push
+	@if gh pr view --json number > /dev/null 2>&1; then \
+		$(MAKE) watch-full create-pr; \
+	else \
+		$(MAKE) create-pr watch-full; \
+	fi
+	@$(MAKE) merge-squash
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright © 2024 - 2026 Caleb Cushing
+# SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
 #
 # SPDX-License-Identifier: MIT
 
@@ -6,6 +6,7 @@ HEAD := $(shell git rev-parse --verify HEAD)
 GRADLE_DIR := $(wildcard ./.gradle/)
 BUILD_DIRS := $(wildcard ./build/ */build/ ./module/*/build/)
 CONFIGURATION_CACHE := $(wildcard $(GRADLE_DIR)configuration-cache/)
+SKILL_FILE := .ai/skills/commit-or-pr-message/SKILL.md
 
 check_defined = $(strip $(foreach 1, $1,$(call __check_defined,$1,$(strip $(value 2)))))
 __check_defined = $(if $(value $1),, $(error Undefined $1$(if $2, ($2))))
@@ -70,22 +71,22 @@ create-pr:
 		./gradlew check; \
 		printf '%s\n' "Updating PR message..."; \
 		./scripts/pr-message.sh --title-file "$$tmp_dir/title.txt" --body-file "$$tmp_dir/body.txt" \
-		  --skill-file ".github/skills/commit-or-pr-message/SKILL.md" || exit 0; \
+		  --skill-file "$(SKILL_FILE)" || exit 0; \
 		head_after=$$(git rev-parse HEAD); \
 		if [ "$$head_before" != "$$head_after" ]; then \
 			./scripts/pr-message.sh --title-file "$$tmp_dir/title.txt" --body-file "$$tmp_dir/body.txt" \
-			  --skill-file ".github/skills/commit-or-pr-message/SKILL.md" || exit 0; \
+			  --skill-file "$(SKILL_FILE)" || exit 0; \
 		fi; \
 		title=$$(cat "$$tmp_dir/title.txt"); \
 		gh pr edit --title "$$title" --body-file "$$tmp_dir/body.txt" || exit 0; \
 		GH_PAGER=cat gh pr view; \
 	else \
 		./scripts/pr-message.sh --title-file "$$tmp_dir/title.txt" --body-file "$$tmp_dir/body.txt" \
-		  --skill-file ".github/skills/commit-or-pr-message/SKILL.md" || exit 0; \
+		  --skill-file "$(SKILL_FILE)" || exit 0; \
 		head_after=$$(git rev-parse HEAD); \
 		if [ "$$head_before" != "$$head_after" ]; then \
 			./scripts/pr-message.sh --title-file "$$tmp_dir/title.txt" --body-file "$$tmp_dir/body.txt" \
-			  --skill-file ".github/skills/commit-or-pr-message/SKILL.md" || exit 0; \
+			  --skill-file "$(SKILL_FILE)" || exit 0; \
 		fi; \
 		title=$$(cat "$$tmp_dir/title.txt"); \
 		gh pr create --title "$$title" --body-file "$$tmp_dir/body.txt" || exit 0; \


### PR DESCRIPTION
- Move skill definitions into .ai/skills and add SPDX headers for 
clarity.
- Add a skill-creator guide outlining the expected structure and 
resources for new skills.
- Update Makefile merge commands to reuse the SKILL_FILE variable and 
streamline workflow steps.
