### PR TITLE
feat(pr-message): add multi-engine AI support (junie, kimi, copilot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-# SPDX-FileCopyrightText: Copyright © 2025, 2026 Caleb Cushing
+# SPDX-FileCopyrightText: Copyright © 2025 2026 Caleb Cushing
+# SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
 #
 # SPDX-License-Identifier: CC0-1.0
 
 ### AI
-*output.txt
+*.txt
 
 # direnv
 !.envrc

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 java temurin-25.0.1+8.0.LTS
 nodejs 24.11.1
 ktlint 1.8.0
-python 3.14.0
+python 3.14.3

--- a/package.json
+++ b/package.json
@@ -15,12 +15,16 @@
     "rimraf": "^6.1.2"
   },
   "scripts": {
+    "cleaner": "rimraf ./build */build ./module/*/build ./.gradle",
     "contributor": "pip install -r requirements.txt && git config core.hooksPath .config/git/hooks",
     "dependencies:for": "./gradlew dependencies --configuration",
-    "merge": "make merge",
+    "merge": "yarn merge:junie",
+    "merge:copilot": "make merge ENGINE=copilot",
+    "merge:junie": "make merge ENGINE=junie",
+    "merge:kimi": "make merge ENGINE=kimi",
     "test": "./gradlew check",
     "ug": "./gradlew dependencies --write-locks --console=plain | grep -e FAILED || exit 0",
-    "ug:scan": "./gradlew dependencies --write-locks --console=plain --scan | grep -e FAILED -e https || exit 0",
-    "cleaner": "rimraf ./build */build ./module/*/build ./.gradle"
+    "ug:dogfood": "./gradlew dependencies --refresh-dependencies --write-locks --console=plain | grep -e FAILED || exit 0",
+    "ug:scan": "./gradlew dependencies --write-locks --console=plain --scan | grep -e FAILED -e https || exit 0"
   }
 }

--- a/scripts/pr-message.sh
+++ b/scripts/pr-message.sh
@@ -8,7 +8,7 @@ set -eu
 
 usage() {
   cat <<'EOF'
-Usage: pr-message.sh --title-file PATH --body-file PATH [--base-ref REF] [--skill-file PATH] [--dry-run]
+Usage: pr-message.sh --title-file PATH --body-file PATH [--engine ENGINE] [--base-ref REF] [--skill-file PATH] [--dry-run]
 
 Generates a Conventional Commit subject and body for PR title/body.
 EOF
@@ -29,33 +29,45 @@ if ! command -v "$YARN_CMD" > /dev/null 2>&1; then
   fi
 fi
 
-if [ ! -f "yarn.lock" ] || ! grep -q "@github/copilot@" yarn.lock; then
-  printf '%s\n' "pr-message: ERROR: @github/copilot is not installed (add it to devDependencies)" 1>&2
-  exit 1
-fi
-
-if ! $YARN_CMD exec copilot --help > /dev/null 2>&1; then
-  printf '%s\n' "pr-message: ERROR: copilot CLI not available via yarn exec" 1>&2
-  exit 1
-fi
-
+ENGINE="${PRMSG_ENGINE:-}"
 TITLE_FILE=""
 BODY_FILE=""
 BASE_REF="${PRMSG_BASE_REF:-}"
 SKILL_FILE="${PRMSG_SKILL_FILE:-}"
 DRY_RUN=0
 
-if [ -z "$BASE_REF" ]; then
-  ORIGIN_HEAD_BRANCH=$(git remote show origin 2> /dev/null | awk '/HEAD branch/ {print $NF}')
-  if [ -n "$ORIGIN_HEAD_BRANCH" ]; then
-    BASE_REF="origin/$ORIGIN_HEAD_BRANCH"
-  else
-    BASE_REF="origin/HEAD"
-  fi
+# Auto-detect available engines
+is_engine_available() {
+  case "$1" in
+    copilot) command -v copilot > /dev/null 2>&1 ;;
+    junie) command -v junie > /dev/null 2>&1 && command -v jq > /dev/null 2>&1 ;;
+    kimi) command -v kimi > /dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# If engine not specified, auto-detect
+if [ -z "$ENGINE" ]; then
+  for try_engine in junie kimi copilot; do
+    if is_engine_available "$try_engine"; then
+      ENGINE="$try_engine"
+      break
+    fi
+  done
+fi
+
+# If still no engine found, error out
+if [ -z "$ENGINE" ]; then
+  printf '%s\n' "pr-message: ERROR: no AI engine found (tried: junie, kimi, copilot)" 1>&2
+  exit 1
 fi
 
 while [ $# -gt 0 ]; do
   case "$1" in
+    --engine)
+      ENGINE="$2"
+      shift 2
+      ;;
     --title-file)
       TITLE_FILE="$2"
       shift 2
@@ -88,9 +100,39 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# Validate engine and fall back if not available
+if ! is_engine_available "$ENGINE"; then
+  log "pr-message: engine '$ENGINE' not available, trying fallback"
+  ORIG_ENGINE="$ENGINE"
+  FOUND=0
+  for try_engine in junie kimi copilot; do
+    if [ "$try_engine" != "$ORIG_ENGINE" ] && is_engine_available "$try_engine"; then
+      ENGINE="$try_engine"
+      FOUND=1
+      log "pr-message: fell back to '$ENGINE'"
+      break
+    fi
+  done
+  if [ "$FOUND" -eq 0 ]; then
+    printf '%s\n' "pr-message: ERROR: engine '$ORIG_ENGINE' not available and no fallback found" 1>&2
+    exit 1
+  fi
+fi
+
+log "pr-message: using engine '$ENGINE'"
+
 if [ -z "$TITLE_FILE" ] || [ -z "$BODY_FILE" ]; then
   usage
   exit 2
+fi
+
+if [ -z "$BASE_REF" ]; then
+  ORIGIN_HEAD_BRANCH=$(git remote show origin 2> /dev/null | awk '/HEAD branch/ {print $NF}')
+  if [ -n "$ORIGIN_HEAD_BRANCH" ]; then
+    BASE_REF="origin/$ORIGIN_HEAD_BRANCH"
+  else
+    BASE_REF="origin/HEAD"
+  fi
 fi
 
 if ! git rev-parse --verify "$BASE_REF" > /dev/null 2>&1; then
@@ -184,51 +226,131 @@ PR diff (truncated):
 ${CHANGED_DIFF}
 "
 
-COPILOT_MODEL="${COPILOT_PRMSG_MODEL:-${COPILOT_COMMITMSG_MODEL:-gpt-5.1-codex-mini}}"
-COPILOT_FALLBACK_MODEL="${COPILOT_PRMSG_FALLBACK_MODEL:-${COPILOT_COMMITMSG_FALLBACK_MODEL:-gpt-5.1-codex}}"
+log "pr-message: invoking $ENGINE (files: $(printf '%s\n' "$CHANGED_FILES" | wc -l | tr -d ' '))"
 
-log "pr-message: invoking copilot (files: $(printf '%s\n' "$CHANGED_FILES" | wc -l | tr -d ' '))"
-log "pr-message: copilot model=$COPILOT_MODEL (fallback=$COPILOT_FALLBACK_MODEL)"
+if [ "$ENGINE" = "junie" ]; then
+  # Use provided skill or default to the one in the project
+  SKILL_PROMPT=""
+  [ -n "$SKILL_SNIPPET" ] && SKILL_PROMPT=" using this skill guidance: $SKILL_SNIPPET"
 
-run_copilot() {
-  _model="$1"
-  _out_file="$2"
-  _err_file="$3"
+  # We ask Junie to write directly to the files to be faster and avoid manual parsing if possible.
+  # We also include the diff to avoid Junie having to discover it.
+  # Note: --cache-dir is set to .junie/cache as requested.
+  # We don't use --output-format=json here so the user can see progress in the terminal.
+  junie --skip-update-check --cache-dir=.junie/cache \
+    "Generate a conventional commit message for the following diff and write the subject line to '$TITLE_FILE' and the body to '$BODY_FILE'. Do not run any tests or gradle commands.$SKILL_PROMPT
 
-  $YARN_CMD exec copilot --model "$_model" -s -p "$PROMPT" > "$_out_file" 2> "$_err_file" || return $?
-}
+Diff:
+$CHANGED_DIFF" || true
 
-TMP_OUT=$(mktemp)
-TMP_ERR=$(mktemp)
+  # Fallback: if files are empty, try the old way or check if Junie wrote something to stdout (not likely with > /dev/null)
+  # Actually, if Junie failed to write the files, we might want to try one more time or just fail.
+  if [ ! -s "$TITLE_FILE" ]; then
+    log "pr-message: junie didn't write to $TITLE_FILE, trying to capture output"
+    AI_OUT=$(junie --skip-update-check --cache-dir=.junie/cache --output-format=json \
+      "Generate a conventional commit message for the following diff and output it as plain text.$SKILL_PROMPT
 
-run_copilot "$COPILOT_MODEL" "$TMP_OUT" "$TMP_ERR" || true
-COPILOT_OUT=$(cat "$TMP_OUT")
-COPILOT_ERR=$(cat "$TMP_ERR")
-
-if printf '%s\n%s' "$COPILOT_OUT" "$COPILOT_ERR" | grep -qi 'enable this model'; then
-  log "pr-message: model '$COPILOT_MODEL' not enabled; falling back to '$COPILOT_FALLBACK_MODEL'"
-  run_copilot "$COPILOT_FALLBACK_MODEL" "$TMP_OUT" "$TMP_ERR" || true
-  COPILOT_OUT=$(cat "$TMP_OUT")
-  COPILOT_ERR=$(cat "$TMP_ERR")
-fi
-
-if [ -z "${COPILOT_OUT:-}" ]; then
-  if [ -n "${COPILOT_ERR:-}" ] && [ -n "${COPILOT_PRMSG_DEBUG:-${COPILOT_COMMITMSG_DEBUG:-}}" ]; then
-    printf '%s\n' "copilot(pr-message): stderr: $COPILOT_ERR" 1>&2
+Diff:
+$CHANGED_DIFF" 2>&1 | jq -r ".result" || echo "")
+  else
+    # If files were written, we are done for Junie
+    AI_OUT=""
+  fi
+elif [ "$ENGINE" = "kimi" ]; then
+  # Use .ai/skills as base skills dir if it exists
+  # Kimi auto-discovers skills from this directory and injects them into the
+  # system prompt. The AI decides when to use the commit-or-pr-message skill.
+  # No need to manually embed SKILL_SNIPPET - it would duplicate the content.
+  SKILLS_DIR_ARG=""
+  if [ -d ".ai/skills" ]; then
+    SKILLS_DIR_ARG=".ai/skills"
   fi
 
-  log "pr-message: empty output; retrying with fallback model '$COPILOT_FALLBACK_MODEL'"
-  run_copilot "$COPILOT_FALLBACK_MODEL" "$TMP_OUT" "$TMP_ERR" || true
-  COPILOT_OUT=$(cat "$TMP_OUT")
+  # Kimi invocation
+  # --no-thinking: faster, more direct output
+  # --quiet: alias for --print --output-format text --final-message-only
+  # --skills-dir: enables auto-discovery of commit-or-pr-message skill
+  if [ -n "$SKILLS_DIR_ARG" ]; then
+    kimi --skills-dir "$SKILLS_DIR_ARG" --no-thinking --quiet --prompt \
+      "Generate a conventional commit message for the following diff and write the subject line to '$TITLE_FILE' and the body to '$BODY_FILE'. Do not run any tests or gradle commands.
+
+Diff:
+$CHANGED_DIFF" || true
+  else
+    kimi --no-thinking --quiet --prompt \
+      "Generate a conventional commit message for the following diff and write the subject line to '$TITLE_FILE' and the body to '$BODY_FILE'. Do not run any tests or gradle commands.
+
+Diff:
+$CHANGED_DIFF" || true
+  fi
+
+  AI_OUT=""
+  if [ ! -s "$TITLE_FILE" ]; then
+    log "pr-message: kimi didn't write to $TITLE_FILE"
+  fi
+else
+  COPILOT_MODEL="${COPILOT_PRMSG_MODEL:-${COPILOT_COMMITMSG_MODEL:-gpt-5.1-codex-mini}}"
+  COPILOT_FALLBACK_MODEL="${COPILOT_PRMSG_FALLBACK_MODEL:-${COPILOT_COMMITMSG_FALLBACK_MODEL:-gpt-5.1-codex}}"
+
+  log "pr-message: copilot model=$COPILOT_MODEL (fallback=$COPILOT_FALLBACK_MODEL)"
+
+  run_copilot() {
+    _model="$1"
+    _out_file="$2"
+    _err_file="$3"
+
+    copilot --model "$_model" -s -p "$PROMPT" > "$_out_file" 2> "$_err_file" || return $?
+  }
+
+  TMP_OUT=$(mktemp)
+  TMP_ERR=$(mktemp)
+
+  run_copilot "$COPILOT_MODEL" "$TMP_OUT" "$TMP_ERR" || true
+  AI_OUT=$(cat "$TMP_OUT")
   COPILOT_ERR=$(cat "$TMP_ERR")
+
+  if printf '%s\n%s' "$AI_OUT" "$COPILOT_ERR" | grep -qi 'enable this model'; then
+    log "pr-message: model '$COPILOT_MODEL' not enabled; falling back to '$COPILOT_FALLBACK_MODEL'"
+    run_copilot "$COPILOT_FALLBACK_MODEL" "$TMP_OUT" "$TMP_ERR" || true
+    AI_OUT=$(cat "$TMP_OUT")
+    COPILOT_ERR=$(cat "$TMP_ERR")
+  fi
+
+  if [ -z "${AI_OUT:-}" ]; then
+    if [ -n "${COPILOT_ERR:-}" ] && [ -n "${COPILOT_PRMSG_DEBUG:-${COPILOT_COMMITMSG_DEBUG:-}}" ]; then
+      printf '%s\n' "copilot(pr-message): stderr: $COPILOT_ERR" 1>&2
+    fi
+
+    log "pr-message: empty output; retrying with fallback model '$COPILOT_FALLBACK_MODEL'"
+    run_copilot "$COPILOT_FALLBACK_MODEL" "$TMP_OUT" "$TMP_ERR" || true
+    AI_OUT=$(cat "$TMP_OUT")
+    COPILOT_ERR=$(cat "$TMP_ERR")
+  fi
+
+  rm -f "$TMP_OUT" "$TMP_ERR"
 fi
 
-rm -f "$TMP_OUT" "$TMP_ERR"
+AI_OUT=$(printf '%s' "$AI_OUT" | sed -e 's/\r$//')
 
-COPILOT_OUT=$(printf '%s' "$COPILOT_OUT" | sed -e 's/\r$//')
+# If AI_OUT is empty but files exist, it means Junie/Kimi wrote them directly
+if [ -z "$AI_OUT" ] && [ -s "$TITLE_FILE" ]; then
+  SUBJECT=$(cat "$TITLE_FILE")
+  # We still want to ensure it's trimmed and fits constraints
+  SUBJECT=$(printf '%s' "$SUBJECT" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' | cut -c1-72)
+  printf '%s\n' "$SUBJECT" > "$TITLE_FILE"
+  log "pr-message: $ENGINE wrote title/body directly"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '%s\n' "Title:"
+    cat "$TITLE_FILE"
+    printf '\n%s\n' "Body:"
+    [ -s "$BODY_FILE" ] && cat "$BODY_FILE"
+  fi
+  exit 0
+fi
 
 SUBJECT_CANDIDATE=$(
-  printf '%s\n' "$COPILOT_OUT" \
+  printf '%s\n' "$AI_OUT" \
     | sed -E 's/^Subject:[[:space:]]*//I' \
     | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
     | awk -v types="$ALLOWED_TYPES_ALT" '
@@ -240,7 +362,7 @@ SUBJECT_CANDIDATE=$(
         if (line ~ /^$/) next
         if (line ~ re) { print line; exit }
         if (ENVIRON["PRMSG_ECHO_IGNORED"] != "") {
-          printf("%s\n", "copilot(pr-message): ignored: " line) > "/dev/stderr"
+          printf("%s\n", "ai(pr-message): ignored: " line) > "/dev/stderr"
         }
       }
     ' \
@@ -251,20 +373,20 @@ SUBJECT_CANDIDATE=$(printf '%s' "$SUBJECT_CANDIDATE" | sed -E "s/^(I'll|I will|S
 
 if [ -z "${SUBJECT_CANDIDATE:-}" ]; then
   if [ "${FAIL_ON_INVALID:-1}" = "1" ]; then
-    log "pr-message: copilot failed to yield a valid subject; using error fallback"
-    SUBJECT="error(copilot): failed to generate message"
+    log "pr-message: $ENGINE failed to yield a valid subject; using error fallback"
+    SUBJECT="error($ENGINE): failed to generate message"
 
     {
-      printf 'Copilot failed to generate a conventional commit message.\n\n'
-      if [ -n "${COPILOT_OUT:-}" ]; then
-        printf 'Output:\n%s\n\n' "$COPILOT_OUT"
+      printf '%s failed to generate a conventional commit message.\n\n' "$ENGINE"
+      if [ -n "${AI_OUT:-}" ]; then
+        printf 'Output:\n%s\n\n' "$AI_OUT"
       fi
-      if [ -n "${COPILOT_ERR:-}" ]; then
+      if [ "$ENGINE" = "copilot" ] && [ -n "${COPILOT_ERR:-}" ]; then
         printf 'Errors:\n%s\n' "$COPILOT_ERR"
       fi
     } > "$BODY_FILE"
   else
-    log "pr-message: copilot did not yield a conventional subject; using heuristic fallback"
+    log "pr-message: $ENGINE did not yield a conventional subject; using heuristic fallback"
     if printf '%s\n' "$CHANGED_FILES" | grep -Eq '(^|/)(README\.md|.*\.md)$'; then
       SUBJECT_CANDIDATE="docs: update documentation"
     elif printf '%s\n' "$CHANGED_FILES" | grep -Eq '(^|/)\.github/'; then
@@ -280,10 +402,10 @@ if [ -z "${SUBJECT_CANDIDATE:-}" ]; then
 else
   SUBJECT=$(printf '%s' "$SUBJECT_CANDIDATE" | cut -c1-72)
 
-  BODY=$(printf '%s\n' "$COPILOT_OUT" | awk 'BEGIN{blank=0} NR==1{next} /^$/{blank=1; next} blank{print}')
+  BODY=$(printf '%s\n' "$AI_OUT" | awk 'BEGIN{blank=0} NR==1{next} /^$/{blank=1; next} blank{print}')
 
   if [ -z "${BODY:-}" ]; then
-    BODY=$(printf '%s\n' "$COPILOT_OUT" | sed -e '1d' | awk 'NF')
+    BODY=$(printf '%s\n' "$AI_OUT" | sed -e '1d' | awk 'NF')
   fi
 
   BODY=$(printf '%s\n' "$BODY" | grep -viE "^(i'll|i will|sure|here's|proposed|suggested|i inspected|let's)\\b" || true)

--- a/skills/commit-or-pr-message/SKILL.md
+++ b/skills/commit-or-pr-message/SKILL.md
@@ -7,8 +7,8 @@ name: commit-or-pr-message
 description: Generates a concise and descriptive commit or PR message based on the code changes.
 license: CC-BY-NC-4.0
 metadata:
-  author: Caleb Cushing
-allowed-tools: bash(git:*) bash(make:*)
+author: Caleb Cushing
+allowed-tools: bash(git:_) bash(make:_)
 ---
 
 ## Instructions
@@ -33,7 +33,6 @@ allowed-tools: bash(git:*) bash(make:*)
   - Do not split a single idea across multiple bullets
   - Explain WHAT and WHY
   - Wrap lines to <= 72 chars
-  -
 
 ## Template
 

--- a/skills/java/SKILL.md
+++ b/skills/java/SKILL.md
@@ -1,0 +1,18 @@
+---
+# SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
+#
+# SPDX-License-Identifier: CC-BY-NC-4.0
+
+name: java
+description: Write Java
+license: CC-BY-NC-4.0
+metadata:
+  author: Caleb Cushing
+allowed-tools: ./gradlew
+---
+
+- prefer `var`, and RHS generics, unless a class cast would be required.
+- prefer `import` over fully qualified class names inlined
+  - do not use `*` imports
+- avoid `private` except with fields. prefer the default "package protected" unless must be `public` or is useful for subclasses.
+- prefer `final` for fields unless they need to be mutable


### PR DESCRIPTION
Add support for multiple AI engines in PR message generation with
auto-detection and fallback capabilities.

- Add engine auto-detection for junie, kimi, and copilot
- Implement engine-specific invocation logic for each AI provider
- Add --engine flag to pr-message.sh for explicit engine selection
- Add merge:copilot, merge:junie, merge:kimi scripts to package.json
- Add new Java coding skill with style guidelines
- Fix YAML formatting in commit-or-pr-message skill metadata
- Remove hardcoded copilot dependency checks for flexibility
