### PR TITLE
build(makefile): fail on pr-message errors and remove auto-merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,22 +36,22 @@ create-pr: build
 	if gh pr view --json number > /dev/null 2>&1; then \
 		printf '%s\n' "Updating PR message..."; \
 		./.share/bin/pr-message.sh --engine "$(ENGINE)" --title-file "$$tmp_dir/title.txt" --body-file "$$tmp_dir/body.txt" \
-		  $(SKILL_ARG) || exit 0; \
+		  $(SKILL_ARG) || exit 1; \
 		head_after=$$(git rev-parse HEAD); \
 		if [ "$$head_before" != "$$head_after" ]; then \
 			./.share/bin/pr-message.sh --engine "$(ENGINE)" --title-file "$$tmp_dir/title.txt" --body-file "$$tmp_dir/body.txt" \
-			  $(SKILL_ARG) || exit 0; \
+			  $(SKILL_ARG) || exit 1; \
 		fi; \
 		title=$$(cat "$$tmp_dir/title.txt"); \
 		gh pr edit --title "$$title" --body-file "$$tmp_dir/body.txt" || exit 0; \
 		GH_PAGER=cat gh pr view; \
 	else \
 		./.share/bin/pr-message.sh --engine "$(ENGINE)" --title-file "$$tmp_dir/title.txt" --body-file "$$tmp_dir/body.txt" \
-		  $(SKILL_ARG) || exit 0; \
+		  $(SKILL_ARG) || exit 1; \
 		head_after=$$(git rev-parse HEAD); \
 		if [ "$$head_before" != "$$head_after" ]; then \
 			./.share/bin/pr-message.sh --engine "$(ENGINE)" --title-file "$$tmp_dir/title.txt" --body-file "$$tmp_dir/body.txt" \
-			  $(SKILL_ARG) || exit 0; \
+			  $(SKILL_ARG) || exit 1; \
 		fi; \
 		title=$$(cat "$$tmp_dir/title.txt"); \
 		gh pr create --title "$$title" --body-file "$$tmp_dir/body.txt" || exit 0; \
@@ -77,7 +77,7 @@ merge-squash:
 		[Nn]|[Nn][Oo]) printf '%s\n' "Merge cancelled."; exit 1 ;; \
 		*) ;; \
 	esac; \
-	gh pr merge --squash --delete-branch --auto
+	gh pr merge --squash --delete-branch
 
 .PHONY: watch-build
 watch-build:


### PR DESCRIPTION
Update Makefile to improve reliability of PR creation and merge workflows.

- Change pr-message.sh exit handling from `|| exit 0` to `|| exit 1`
  to ensure build fails when message generation encounters errors
- Remove `--auto` flag from `gh pr merge` to require manual merge
  approval instead of automatic merging